### PR TITLE
Update the drawing part with Builder and Factory

### DIFF
--- a/simulation.py
+++ b/simulation.py
@@ -22,6 +22,102 @@ from visualiser import FigureSimulation, Draw, FigureSIR
 
 # i'm supposed to make productive changes so this is going to be a
 # productive comment. YAY!
+class SimsPopulation:
+    def __init__(self, Config):
+        self.Config = Config
+        self.init()
+    @property
+    def destinations(self):
+        return self._destinations
+    @property
+    def population(self):
+        return self._population
+    def init(self):
+        self._population = initialize_population(self.Config, self.Config.mean_age,
+                                                self.Config.max_age, self.Config.xbounds,
+                                                self.Config.ybounds)
+        self._destinations = initialize_destination_matrix(self.Config.pop_size, 1)
+
+    def iter_init(self, **kargs):
+        self.frame = kargs['frame']
+    def move(self):
+        self._update_move_direction()
+        self._update_move_speed()
+        self._update_final_position()
+    def live(self):
+        self._update_infection()
+        self._update_final_health_status()
+
+        #send cured back to population if self isolation active
+        #perhaps put in recover or die class
+        #send cured back to population
+        self.population[:,11][self.population[:,6] == 2] = 0
+    def iter_end(self):
+        pass
+
+    def _update_move_direction(self):
+        #check destinations if active
+        #define motion vectors if destinations active and not everybody is at destination
+        active_dests = len(self._population[self._population[:,11] != 0]) # look op this only once
+
+        if active_dests > 0 and len(self._population[self._population[:,12] == 0]) > 0:
+            self._population = set_destination(self._population, self._destinations)
+            self._population = check_at_destination(self._population, self._destinations,
+                                                   wander_factor = self.Config.wander_factor_dest,
+                                                   speed = self.Config.speed)
+
+        if active_dests > 0 and len(self._population[self._population[:,12] == 1]) > 0:
+            #keep them at destination
+            self._population = keep_at_destination(self._population, self._destinations,
+                                                  self.Config.wander_factor)
+
+
+        #out of bounds
+        #define bounds arrays, excluding those who are marked as having a custom destination
+        if len(self._population[:,11] == 0) > 0:
+            _xbounds = np.array([[self.Config.xbounds[0] + 0.02, self.Config.xbounds[1] - 0.02]] * len(self._population[self._population[:,11] == 0]))
+            _ybounds = np.array([[self.Config.ybounds[0] + 0.02, self.Config.ybounds[1] - 0.02]] * len(self._population[self._population[:,11] == 0]))
+            self._population[self._population[:,11] == 0] = out_of_bounds(self._population[self._population[:,11] == 0],
+                                                                        _xbounds, _ybounds)
+    def _update_move_speed(self):
+        #set randoms
+        if self.Config.lockdown:
+            if len(self.pop_tracker.infectious) == 0:
+                mx = 0
+            else:
+                mx = np.max(self.pop_tracker.infectious)
+
+            if len(self._population[self._population[:,6] == 1]) >= len(self._population) * self.Config.lockdown_percentage or\
+               mx >= (len(self._population) * self.Config.lockdown_percentage):
+                #reduce speed of all members of society
+                self._population[:,5] = np.clip(self._population[:,5], a_min = None, a_max = 0.001)
+                #set speeds of complying people to 0
+                self._population[:,5][self.Config.lockdown_vector == 0] = 0
+            else:
+                #update randoms
+                self._population = update_randoms(self._population, self.Config.pop_size, self.Config.speed)
+        else:
+            #update randoms
+            self._population = update_randoms(self._population, self.Config.pop_size, self.Config.speed)
+
+    def _update_final_position(self):
+        #for dead ones: set speed and heading to 0
+        self._population[:,3:5][self._population[:,6] == 3] = 0
+
+        #update positions
+        self._population = update_positions(self._population)
+
+    def _update_infection(self):
+        #find new infections
+        self._population, self._destinations = infect(self._population, self.Config, self.frame,
+                                                    send_to_location = self.Config.self_isolate,
+                                                    location_bounds = self.Config.isolation_bounds,
+                                                    destinations = self._destinations,
+                                                    location_no = 1,
+                                                    location_odds = self.Config.self_isolate_proportion)
+    def _update_final_health_status(self):
+        #recover and die
+        self._population = recover_or_die(self._population, self.frame, self.Config)
 
 class Simulation():
     #TODO: if lockdown or otherwise stopped: destination -1 means no motion
@@ -31,12 +127,9 @@ class Simulation():
         self.frame = 0
 
         #initialize default population
-        self.population_init()
-
+        self.Population = SimsPopulation(self.Config)
         self.pop_tracker = Population_trackers()
-
-        #initalise destinations vector
-        self.destinations = initialize_destination_matrix(self.Config.pop_size, 1)
+        
         self.figure_tstep = FigureSimulation(self.Config, figsize = (5,7))
         self.drawer_tstep = Draw(self.figure_tstep)
         
@@ -44,89 +137,45 @@ class Simulation():
         '''reset the simulation'''
 
         self.frame = 0
-        self.population_init()
+        self.Population.init()
         self.pop_tracker = Population_trackers()
-        self.destinations = initialize_destination_matrix(self.Config.pop_size, 1)
-
-
-    def population_init(self):
-        '''(re-)initializes population'''
-        self.population = initialize_population(self.Config, self.Config.mean_age,
-                                                self.Config.max_age, self.Config.xbounds,
-                                                self.Config.ybounds)
 
 
     def tstep(self):
         '''
         takes a time step in the simulation
         '''
+        # init Population at the begin of each iteration
+        self.Population.iter_init(frame = self.frame)
+        # update the movement status, like headings, speed, destinations.
+        self.Population.move()
+        # update the results of infections, and the health conditions for people
+        self.Population.live()
+        # Update other information at the end of the iteration.
+        self.Population.iter_end()
 
-        #update populations' destination conditioning on their current status and the information of destinations.                                                          _xbounds, _ybounds)
-        self.population = update_pops_destination(self.population, self.destinations, self.Config)
-
-        #set randoms
-        if self.Config.lockdown:
-            if len(self.pop_tracker.infectious) == 0:
-                mx = 0
-            else:
-                mx = np.max(self.pop_tracker.infectious)
-
-            if len(self.population[self.population[:,6] == 1]) >= len(self.population) * self.Config.lockdown_percentage or\
-               mx >= (len(self.population) * self.Config.lockdown_percentage):
-                #reduce speed of all members of society
-                self.population[:,5] = np.clip(self.population[:,5], a_min = None, a_max = 0.001)
-                #set speeds of complying people to 0
-                self.population[:,5][self.Config.lockdown_vector == 0] = 0
-            else:
-                #update randoms
-                self.population = update_randoms(self.population, self.Config.pop_size, self.Config.speed)
-        else:
-            #update randoms
-            self.population = update_randoms(self.population, self.Config.pop_size, self.Config.speed)
-
-        #for dead ones: set speed and heading to 0
-        self.population[:,3:5][self.population[:,6] == 3] = 0
-
-        #update positions
-        self.population = update_positions(self.population)
-
-        #find new infections
-        self.population, self.destinations = infect(self.population, self.Config, self.frame,
-                                                    send_to_location = self.Config.self_isolate,
-                                                    location_bounds = self.Config.isolation_bounds,
-                                                    destinations = self.destinations,
-                                                    location_no = 1,
-                                                    location_odds = self.Config.self_isolate_proportion)
-
-        #recover and die
-        self.population = recover_or_die(self.population, self.frame, self.Config)
-
-        #send cured back to population if self isolation active
-        #perhaps put in recover or die class
-        #send cured back to population
-        self.population[:,11][self.population[:,6] == 2] = 0
 
         #update population statistics
-        self.pop_tracker.update_counts(self.population)
+        self.pop_tracker.update_counts(self.Population.population)
 
         #visualise
         if self.Config.visualise:
             if self.Config.self_isolate and self.Config.isolation_bounds != None:
-                self.drawer_tstep.draw_environmently(population = self.population, pop_tracker = self.pop_tracker, frame = self.frame)
+                self.drawer_tstep.draw_environmently(population = self.Population.population, pop_tracker = self.pop_tracker, frame = self.frame)
             else:
-                self.drawer_tstep.draw(population = self.population, pop_tracker = self.pop_tracker, frame = self.frame)
+                self.drawer_tstep.draw(population = self.Population.population, pop_tracker = self.pop_tracker, frame = self.frame)
 
 
         #report stuff to console
         sys.stdout.write('\r')
         sys.stdout.write('%i: healthy: %i, infected: %i, immune: %i, in treatment: %i, \
 dead: %i, of total: %i' %(self.frame, self.pop_tracker.susceptible[-1], self.pop_tracker.infectious[-1],
-                        self.pop_tracker.recovered[-1], len(self.population[self.population[:,10] == 1]),
+                        self.pop_tracker.recovered[-1], len(self.Population.population[self.Population.population[:,10] == 1]),
                         self.pop_tracker.fatalities[-1], self.Config.pop_size))
 
         #save popdata if required
         if self.Config.save_pop and (self.frame % self.Config.save_pop_freq) == 0:
-            save_population(self.population, self.frame, self.Config.save_pop_folder)
+            save_population(self.Population.population, self.frame, self.Config.save_pop_folder)
         if self.Config.save_plot:
             self.figure_tstep.save(self.frame)
             
@@ -146,9 +195,9 @@ dead: %i, of total: %i' %(self.frame, self.pop_tracker.susceptible[-1], self.pop
 
         if self.frame == 50:
             print('\ninfecting patient zero')
-            self.population[0][6] = 1
-            self.population[0][8] = 50
-            self.population[0][10] = 1
+            self.Population.population[0][6] = 1
+            self.Population.population[0][8] = 50
+            self.Population.population[0][10] = 1
 
 
     def run(self):
@@ -167,22 +216,22 @@ dead: %i, of total: %i' %(self.frame, self.pop_tracker.susceptible[-1], self.pop
             #check if self.frame is above some threshold to prevent early breaking when simulation
             #starts initially with no infections.
             if self.Config.endif_no_infections and self.frame >= 500:
-                if len(self.population[(self.population[:,6] == 1) |
-                                       (self.population[:,6] == 4)]) == 0:
+                if len(self.Population.population[(self.Population.population[:,6] == 1) |
+                                       (self.Population.population[:,6] == 4)]) == 0:
                     i = self.Config.simulation_steps
 
         if self.Config.save_data:
-            save_data(self.population, self.pop_tracker)
+            save_data(self.Population.population, self.pop_tracker)
 
         #report outcomes
         print('\n-----stopping-----\n')
         print('total timesteps taken: %i' %self.frame)
-        print('total dead: %i' %len(self.population[self.population[:,6] == 3]))
-        print('total recovered: %i' %len(self.population[self.population[:,6] == 2]))
-        print('total infected: %i' %len(self.population[self.population[:,6] == 1]))
-        print('total infectious: %i' %len(self.population[(self.population[:,6] == 1) |
-                                                          (self.population[:,6] == 4)]))
-        print('total unaffected: %i' %len(self.population[self.population[:,6] == 0]))
+        print('total dead: %i' %len(self.Population.population[self.Population.population[:,6] == 3]))
+        print('total recovered: %i' %len(self.Population.population[self.Population.population[:,6] == 2]))
+        print('total infected: %i' %len(self.Population.population[self.Population.population[:,6] == 1]))
+        print('total infectious: %i' %len(self.Population.population[(self.Population.population[:,6] == 1) |
+                                                          (self.Population.population[:,6] == 4)]))
+        print('total unaffected: %i' %len(self.Population.population[self.Population.population[:,6] == 0]))
 
 
     def plot_sir(self, size=(6,3), include_fatalities=False,

--- a/visualiser.py
+++ b/visualiser.py
@@ -121,7 +121,7 @@ class FigureSIR(Figure):
         self.ax_list[0].plot(pop_tracker.infectious, color=self.palette[1], label='infectious')
         self.ax_list[0].plot(pop_tracker.recovered, color=self.palette[2], label='recovered')
         if kwargs['include_fatalities']:
-            self.ax_list[0].plot(pop_tracker.fatalities, color=palette[3], label='fatalities')   
+            self.ax_list[0].plot(pop_tracker.fatalities, color=self.palette[3], label='fatalities')   
         #add axis labels
         self.ax_list[0].xlabel('time in hours')
         self.ax_list[0].ylabel('population')


### PR DESCRIPTION
Previously, graphs are drawn step by step from method build to draw_tstep. Moreover, the SIR plot and Tracking plot are independent, though they have similar realizing procedures, and are both under the control of Config.
Considering that the SIR figure and Tracking figure are both the derivation of figures, and have similar properties, I design an abstract class named Figure, and then SIR, as well as Tracking, inherit from this abstract class.
Moreover, considering the complicated initialization process of figures, I also construct a builder named Drawer, which aggregates the initialization process and provide us with an easier way for further modifications.

After reconstructing the drawing part in visualiser.py, we replace the raw drawing part with the builder Drawer and factory Figure. Then, without calling construct the graph step by step all over the file, the simulation process can now communicate with the builder directly, avoiding potential mess.