### PR TITLE
Update the drawing part with Builder and Factory

### DIFF
--- a/visualiser.py
+++ b/visualiser.py
@@ -121,7 +121,7 @@ class FigureSIR(Figure):
         self.ax_list[0].plot(pop_tracker.infectious, color=self.palette[1], label='infectious')
         self.ax_list[0].plot(pop_tracker.recovered, color=self.palette[2], label='recovered')
         if kwargs['include_fatalities']:
-            self.ax_list[0].plot(pop_tracker.fatalities, color=palette[3], label='fatalities')   
+            self.ax_list[0].plot(pop_tracker.fatalities, color=self.palette[3], label='fatalities')   
         #add axis labels
         self.ax_list[0].xlabel('time in hours')
         self.ax_list[0].ylabel('population')


### PR DESCRIPTION
Previously, graphs are drawn step by step from method build to draw_tstep. Moreover, the SIR plot and Tracking plot are independent, though they have similar realizing procedures, and are both under the control of Config.
Considering that the SIR figure and Tracking figure are both the derivation of figures, and have similar properties, I design an abstract class named Figure, and then SIR, as well as Tracking, inherit from this abstract class.
Moreover, considering the complicated initialization process of figures, I also construct a builder named Drawer, which aggregates the initialization process and provide us with an easier way for further modifications.

After reconstructing the drawing part in visualiser.py, we replace the raw drawing part with the builder Drawer and factory Figure. Then, without calling construct the graph step by step all over the file, the simulation process can now communicate with the builder directly, avoiding potential mess.